### PR TITLE
64-bit integer fixes on Windows; small usability improvements.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -22,26 +22,29 @@
 ## WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ##
 import os, glob, sys
-from distutils.core import setup
-from distutils.extension import Extension
+try:
+  from setuptools import setup, Extension
+except:
+  from distutils.core import setup
+  from distutils.extension import Extension
 from distutils.sysconfig import get_config_var
 
 if get_config_var("OPT") is not None:
   os.environ["OPT"] = get_config_var("OPT").replace("-Wstrict-prototypes","")
 
+compiler_args=[]
+
 if sys.platform == "win32":
     if "VS90COMNTOOLS" not in os.environ:
-        if "VS100COMNTOOLS" in os.environ:
-            os.environ["VS90COMNTOOLS"] = os.environ["VS100COMNTOOLS"]
-        elif "VS110COMNTOOLS" in os.environ:
-            os.environ["VS90COMNTOOLS"] = os.environ["VS110COMNTOOLS"]
-        elif "VS120COMNTOOLS" in os.environ:
-            os.environ["VS90COMNTOOLS"] = os.environ["VS120COMNTOOLS"]
+        for key, value in os.environ.items():
+            if key.startswith("VS") and key.endswith("COMNTOOLS"):
+                os.environ["VS90COMNTOOLS"] = value
+                break
         else:
-          print >>sys.stderr, "The Visual Studio environment variables do not appear to be set. Re-run this setup script from a Visual Studio Command Prompt."
-          exit(-1)
+            print >>sys.stderr, "The Visual Studio environment variables do not appear to be set. Re-run this setup script from a Visual Studio Command Prompt."
+            exit(-1)
 else:
-    compiler_args=["-std=c++11"]
+    compiler_args.extend(["-std=c++11"])
 
 setup(name='bflat-python',
       description='BFlat Python Module',

--- a/python/src/bflat/__init__.py
+++ b/python/src/bflat/__init__.py
@@ -33,3 +33,6 @@ def loads(value):
     """Decodes a BFlat-encoded data string, returning a dictionary."""
     return _bflat_native.loads(value)
 
+def version():
+    """Returns the current version of the native implementation."""
+    return _bflat_native.version()

--- a/python/src/bflat_python.cpp
+++ b/python/src/bflat_python.cpp
@@ -111,7 +111,7 @@ bflat::value_type python_to_bflat_type(PyObject* value, int64_t& int_value)
 #ifdef IS_PY3X
   if(PyLong_Check(value))
   {
-    int_value = PyNumber_AsSsize_t(value,NULL);
+    int_value = PyLong_AsUnsignedLongLongMask(value);
     return bflat::int64_type; // we'll narrow later
   }
   else if(PyBytes_Check(value) || PyUnicode_Check(value))
@@ -404,7 +404,7 @@ static PyObject* bflat_native_dumps(PyObject *self, PyObject* args)
 #ifdef IS_PY3X
     if(PyLong_Check(value))
     {
-      long long_value = PyLong_AS_LONG(value);
+      int64_t long_value = (int64_t)PyLong_AsUnsignedLongLongMask(value);
       append_smallest_integer(serializer,key_string,key_length,long_value);
     }
     else if(PyUnicode_Check(value))
@@ -768,11 +768,18 @@ static PyObject* bflat_native_loads(PyObject* self, PyObject* args)
   return dict;
 }
 
+static PyObject* bflat_native_version(PyObject*, PyObject*)
+{
+  return PyFloat_FromDouble(bflat::version);
+}
+
 static PyMethodDef bflat_native_methods[] = {
   {"dumps", bflat_native_dumps, METH_VARARGS,
    "Convert a python mapping object to a BFlat string."},
   {"loads", bflat_native_loads, METH_VARARGS,
    "Convert a BFlat string to a python dictionary."},
+  {"version", bflat_native_version, METH_VARARGS,
+   "Returns the implementation version."},
   {NULL}
 };
 

--- a/python/test/test_dumps.py
+++ b/python/test/test_dumps.py
@@ -35,10 +35,12 @@ class TestBflatDumps(unittest.TestCase):
         pass
 
     def test_encode_ints(self):
-        data = [0, -1, 1, 127, 128, -127, -128, -32767, -32768, -65535, -65536, MAX, -1 * MAX]
-        data = dict([(str(i), data[i]) for i in range(len(data))])
-        encoded = bflat.dumps(data)
-        assert bflat.loads(encoded) == data
+        intarray = [0, -1, 1, 127, 128, -127, -128, -32767, -32768]
+        for x in [[], [-65535, -65536, MAX, -1 * MAX], [-2147483647, -2147483648], [9223372036854775807, -9223372036854775808]]:
+            intarray.extend(x)
+            data = dict([(str(i), intarray[i]) for i in range(len(intarray))])
+            encoded = bflat.dumps(data)
+            assert bflat.loads(encoded) == data
 
     def test_encode_doubles(self):
         data = [0.0, -1.0, 1.0, 127.0, 128.01, -127.001, -128.0001, -32767.1, -32768.1, -65535.01, -65536.001, MAX - 0.001, -1.01 * MAX]
@@ -53,10 +55,12 @@ class TestBflatDumps(unittest.TestCase):
         assert bflat.loads(encoded) == data
 
     def test_encode_int_array(self):
-        data = [0, -1, 1, 127, 128, -127, -128, -32767, -32768, -65535, -65536, MAX, -1 * MAX]
-        data = {"values": data}
-        encoded = bflat.dumps(data)
-        assert bflat.loads(encoded) == data
+        intarray = [0, -1, 1, 127, 128, -127, -128, -32767, -32768]
+        for x in [[], [-65535, -65536, MAX, -1 * MAX], [-2147483647, -2147483648], [9223372036854775807, -9223372036854775808]]:
+            intarray.extend(x)
+            data = {"values": intarray}
+            encoded = bflat.dumps(data)
+            assert bflat.loads(encoded) == data
 
     def test_encode_double_array(self):
         data = [0.0, -1.0, 1.0, 127.0, 128.01, -127.001, -128.0001, -32767.1, -32768.1, -65535.01, -65536.001, MAX - 0.001, -1.01 * MAX]


### PR DESCRIPTION
- Fixing C++ compilation of 'decode_uleb_128' on 32-bit platform;
- Fixing integer conversions for Windows/Py3;
- Adding tests for the fixed integer conversion;
- Eliminating C++ compilation warnings;
- Adding version info;
- Extending Python setup for newer MSVC compilers and for optional building of wheels distribution.